### PR TITLE
add simple dependency test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,20 @@ jobs:
         uses: quentinguidee/pep8-action@v1
         with:
           arguments: '--max-line-length=120'
+
+  dependencies:
+    name: Check app runtime
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run main.py with --desc
+        run: |
+          python3 main.py --desc

--- a/main.py
+++ b/main.py
@@ -14,10 +14,12 @@ def print_statistics(api_endpoint: dspyce.rest.RestAPI, human_readable=True) -> 
         stats = json.dumps(stats, indent=2)
     print(stats)
 
-
-if __name__ == "__main__":
+def access_demo_api_and_print_statistics() -> None:
     print("Demo implementation of a dspyce library")
     url = "https://demo.dspace.org/server/api"
-    apiEndpoint = get_rest_api_connection(url)
-    print_statistics(apiEndpoint)
+    api_endpoint = get_rest_api_connection(url)
+    print_statistics(api_endpoint)
     print("Demo successfully finished")
+
+if __name__ == "__main__":
+    access_demo_api_and_print_statistics()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import dspyce
 import json
 
@@ -21,5 +22,15 @@ def access_demo_api_and_print_statistics() -> None:
     print_statistics(api_endpoint)
     print("Demo successfully finished")
 
+def print_app_description() -> None:
+    print("Demo implementation of a dspyce library")
+
 if __name__ == "__main__":
-    access_demo_api_and_print_statistics()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--desc', action='store_true', help='Request common description')
+    args = parser.parse_args()
+
+    if args.desc:
+        print_app_description()
+    else:
+        access_demo_api_and_print_statistics()

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ def print_statistics(api_endpoint: dspyce.rest.RestAPI, human_readable=True) -> 
         stats = json.dumps(stats, indent=2)
     print(stats)
 
+
 def access_demo_api_and_print_statistics() -> None:
     print("Demo implementation of a dspyce library")
     url = "https://demo.dspace.org/server/api"
@@ -22,8 +23,10 @@ def access_demo_api_and_print_statistics() -> None:
     print_statistics(api_endpoint)
     print("Demo successfully finished")
 
+
 def print_app_description() -> None:
     print("Demo implementation of a dspyce library")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
`v0.0.3` of dspyce breaks the demo, because of a new dependency, which seems missing. So I try to add a simple print-description-call via cli which breaks, when a library is missing. This PR refactors the  demo, adds the cli parameter handling and checks the non-breaking via CI.